### PR TITLE
Make buildifier run on changed files only, not all files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 -   id: bazel-buildifier
     name: 'bazel buildifier'
-    entry: run-bazel-buildifier.sh
-    files: 'BUILD.bazel|BUILD'
-    language: 'script'
+    entry: buildifier
+    files: 'BUILD.bazel|BUILD|WORKSPACE'
+    language: 'system'
     description: "Runs `buildifier`, requires bazel buildifier"
 -   id: go-imports
     name: 'go imports'

--- a/run-bazel-buildifier.sh
+++ b/run-bazel-buildifier.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-exec buildifier $(find . -type f \( -iname BUILD -or -iname BUILD.bazel -or -iname WORKSPACE \))


### PR DESCRIPTION
Pre-Commit will pass the list of changed files that match the rule's pattern. This means the script isn't needed, and the rule can use the 'system' language.