### PR TITLE
Update bazel to match only extension or whole name

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: bazel-buildifier
     name: 'bazel buildifier'
     entry: run-bazel-buildifier.sh
-    files: 'BUILD.bazel|BUILD'
+    files: '(^(BUILD\.bazel|BUILD)|/\2|\.BUILD)$'
     language: 'script'
     description: "Runs `buildifier`, requires bazel buildifier"
 -   id: go-imports


### PR DESCRIPTION
The hook was originally matching all files in the repository as long as they had `BUILD` or `BUILD.bazel` in them. This commit ensures that, for example, `BUILD.bazel` and `whatever/BUILD.bazel` match, but not `whateverBUILD.bazelasdf`. It also adds support for `whatever.BUILD` files.

See #2 